### PR TITLE
Fix core ResultSet reading and add unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,30 @@
-# name: Maven Build
+name: Maven Build
 
-# on:
-#   workflow_dispatch:
-#   push:
-#     branches: [ "main" ]
-#   pull_request:
-#     branches: [ "main" ]
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
-# jobs:
-#   build:
+jobs:
+  build:
 
-#     runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-#     steps:
-#     - name: Checkout Repository
-#       uses: actions/checkout@v4
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
 
-#     - name: Set up JDK 8
-#       uses: actions/setup-java@v4
-#       with:
-#         java-version: '8'
-#         distribution: 'temurin'
-#         cache: maven
+    - name: Set up JDK 8
+      uses: actions/setup-java@v4
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
 
-#     - name: Build with Maven
-#       run: mvn -B package --file pom.xml
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
 
-#     - name: Update Dependency Graph
-#       uses: advanced-security/maven-dependency-submission-action@v4
+    - name: Update Dependency Graph
+      uses: advanced-security/maven-dependency-submission-action@v4

--- a/src/main/java/io/github/mapepire_ibmi/App.java
+++ b/src/main/java/io/github/mapepire_ibmi/App.java
@@ -23,7 +23,7 @@ public final class App {
             Statement statement = connection.createStatement();
             ResultSet rs = statement.executeQuery("SELECT * FROM SAMPLE.DEPARTMENT");
             rs.next();
-            String DEPTNO = rs.getString(1);
+            String deptno = rs.getString(1);
 
             connection.close();
             System.out.println("Done");

--- a/src/main/java/io/github/mapepire_ibmi/MapepireConnection.java
+++ b/src/main/java/io/github/mapepire_ibmi/MapepireConnection.java
@@ -15,7 +15,6 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
@@ -377,7 +376,8 @@ public class MapepireConnection implements Connection {
     @Override
     public String getSchema() throws SQLException {
         try {
-            QueryResult<LinkedHashMap<String, String>> result = this.job.<LinkedHashMap<String, String>>execute("SELECT CURRENT SCHEMA FROM SYSIBM.SYSDUMMY1").get();
+            QueryResult<Map<String, String>> result = this.job
+                    .<Map<String, String>>execute("SELECT CURRENT SCHEMA FROM SYSIBM.SYSDUMMY1").get();
             if (result.getSuccess()) {
                 return result.getData().get(0).entrySet().iterator().next().getValue();
             } else {

--- a/src/main/java/io/github/mapepire_ibmi/MapepireResultSet.java
+++ b/src/main/java/io/github/mapepire_ibmi/MapepireResultSet.java
@@ -21,7 +21,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import io.github.mapepire_ibmi.types.QueryResult;
@@ -29,7 +28,7 @@ import io.github.mapepire_ibmi.types.QueryResult;
 public class MapepireResultSet implements ResultSet {
     private QueryResult<Object> result;
     private Iterator<Object> rowIterator;
-    private LinkedHashMap<String, Object> currentRow;
+    private Map<String, Object> currentRow;
 
     public MapepireResultSet(QueryResult<Object> result) {
         this.result = result;
@@ -52,7 +51,7 @@ public class MapepireResultSet implements ResultSet {
     @SuppressWarnings("unchecked")
     public boolean next() throws SQLException {
         if (rowIterator.hasNext()) {
-            this.currentRow = (LinkedHashMap<String, Object>) this.rowIterator.next();
+            this.currentRow = (Map<String, Object>) this.rowIterator.next();
             return true;
         }
 
@@ -74,7 +73,7 @@ public class MapepireResultSet implements ResultSet {
 
     @Override
     public String getString(int columnIndex) throws SQLException {
-        if(this.currentRow == null) {
+        if (this.currentRow == null) {
             throw new SQLException("No current row for ResultSet");
         } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
             throw new SQLException("Invalid column index");

--- a/src/main/java/io/github/mapepire_ibmi/MapepireResultSet.java
+++ b/src/main/java/io/github/mapepire_ibmi/MapepireResultSet.java
@@ -79,55 +79,96 @@ public class MapepireResultSet implements ResultSet {
             throw new SQLException("Invalid column index");
         }
 
-        return (String) this.currentRow.values().toArray()[columnIndex - 1];
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? null : value.toString();
     }
 
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBoolean'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value != null && (Boolean) value;
     }
 
     @Override
     public byte getByte(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getByte'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? 0 : ((Number) value).byteValue();
     }
 
     @Override
     public short getShort(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getShort'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? 0 : ((Number) value).shortValue();
     }
 
     @Override
     public int getInt(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getInt'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? 0 : ((Number) value).intValue();
     }
 
     @Override
     public long getLong(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getLong'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? 0L : ((Number) value).longValue();
     }
 
     @Override
     public float getFloat(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getFloat'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? 0.0f : ((Number) value).floatValue();
     }
 
     @Override
     public double getDouble(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getDouble'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? 0.0d : ((Number) value).doubleValue();
     }
 
     @Override
     public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBigDecimal'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        } else if (columnIndex < 1 || columnIndex > this.currentRow.size()) {
+            throw new SQLException("Invalid column index");
+        }
+        Object value = this.currentRow.values().toArray()[columnIndex - 1];
+        return value == null ? null : new BigDecimal(value.toString());
     }
 
     @Override
@@ -138,20 +179,20 @@ public class MapepireResultSet implements ResultSet {
 
     @Override
     public Date getDate(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getDate'");
+        String value = getString(columnIndex);
+        return value == null ? null : Date.valueOf(value);
     }
 
     @Override
     public Time getTime(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getTime'");
+        String value = getString(columnIndex);
+        return value == null ? null : Time.valueOf(value);
     }
 
     @Override
     public Timestamp getTimestamp(int columnIndex) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getTimestamp'");
+        String value = getString(columnIndex);
+        return value == null ? null : Timestamp.valueOf(value);
     }
 
     @Override
@@ -174,56 +215,47 @@ public class MapepireResultSet implements ResultSet {
 
     @Override
     public String getString(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getString'");
+        return getString(findColumn(columnLabel));
     }
 
     @Override
     public boolean getBoolean(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBoolean'");
+        return getBoolean(findColumn(columnLabel));
     }
 
     @Override
     public byte getByte(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getByte'");
+        return getByte(findColumn(columnLabel));
     }
 
     @Override
     public short getShort(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getShort'");
+        return getShort(findColumn(columnLabel));
     }
 
     @Override
     public int getInt(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getInt'");
+        return getInt(findColumn(columnLabel));
     }
 
     @Override
     public long getLong(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getLong'");
+        return getLong(findColumn(columnLabel));
     }
 
     @Override
     public float getFloat(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getFloat'");
+        return getFloat(findColumn(columnLabel));
     }
 
     @Override
     public double getDouble(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getDouble'");
+        return getDouble(findColumn(columnLabel));
     }
 
     @Override
     public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBigDecimal'");
+        return getBigDecimal(findColumn(columnLabel), scale);
     }
 
     @Override
@@ -234,20 +266,17 @@ public class MapepireResultSet implements ResultSet {
 
     @Override
     public Date getDate(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getDate'");
+        return getDate(findColumn(columnLabel));
     }
 
     @Override
     public Time getTime(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getTime'");
+        return getTime(findColumn(columnLabel));
     }
 
     @Override
     public Timestamp getTimestamp(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getTimestamp'");
+        return getTimestamp(findColumn(columnLabel));
     }
 
     @Override
@@ -306,8 +335,17 @@ public class MapepireResultSet implements ResultSet {
 
     @Override
     public int findColumn(String columnLabel) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findColumn'");
+        if (this.currentRow == null) {
+            throw new SQLException("No current row for ResultSet");
+        }
+        int index = 1;
+        for (String key : this.currentRow.keySet()) {
+            if (key.equalsIgnoreCase(columnLabel)) {
+                return index;
+            }
+            index++;
+        }
+        throw new SQLException("Column not found: " + columnLabel);
     }
 
     @Override

--- a/src/main/java/io/github/mapepire_ibmi/MapepireStatement.java
+++ b/src/main/java/io/github/mapepire_ibmi/MapepireStatement.java
@@ -35,8 +35,8 @@ public class MapepireStatement implements Statement {
     @Override
     public ResultSet executeQuery(String sql) throws SQLException {
         try {
-            Query query = this.connection.getJob().query(sql);
-            QueryResult<Object> result = query.execute().get();
+            this.query = this.connection.getJob().query(sql);
+            QueryResult<Object> result = this.query.execute().get();
 
             return new MapepireResultSet(result);
         } catch (Exception e) {
@@ -47,8 +47,8 @@ public class MapepireStatement implements Statement {
     @Override
     public int executeUpdate(String sql) throws SQLException {
         try {
-            Query query = this.connection.getJob().query(sql);
-            QueryResult<Object> result = query.execute().get();
+            this.query = this.connection.getJob().query(sql);
+            QueryResult<Object> result = this.query.execute().get();
             return result.getUpdateCount();
         } catch (Exception e) {
             throw new SQLException(e);
@@ -133,8 +133,8 @@ public class MapepireStatement implements Statement {
     @Override
     public boolean execute(String sql) throws SQLException {
         try {
-            Query query = this.connection.getJob().query(sql);
-            this.result = query.execute().get();
+            this.query = this.connection.getJob().query(sql);
+            this.result = this.query.execute().get();
 
             return result.getHasResults();
         } catch (Exception e) {

--- a/src/test/java/io/github/mapepire_ibmi/AppTest.java
+++ b/src/test/java/io/github/mapepire_ibmi/AppTest.java
@@ -1,18 +1,38 @@
 package io.github.mapepire_ibmi;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-/**
- * Unit test for simple App.
- */
 class AppTest {
-    /**
-     * Rigorous Test.
-     */
+
     @Test
-    void testApp() {
-        assertEquals(1, 1);
+    void driverVersionIsCorrect() {
+        MapepireDriver driver = new MapepireDriver();
+        assertEquals(1, driver.getMajorVersion());
+        assertEquals(0, driver.getMinorVersion());
+    }
+
+    @Test
+    void driverAcceptsValidMapepireUrl() throws SQLException {
+        MapepireDriver driver = new MapepireDriver();
+        assertTrue(driver.acceptsURL("jdbc:mapepire://myhost.example.com:8076"));
+    }
+
+    @Test
+    void driverRejectsNonMapepireUrl() throws SQLException {
+        MapepireDriver driver = new MapepireDriver();
+        assertFalse(driver.acceptsURL("jdbc:postgresql://localhost:5432/db"));
+    }
+
+    @Test
+    void driverJdbcCompliantReturnsFalse() {
+        // Not fully compliant yet — must stay false until all JDBC API is implemented
+        MapepireDriver driver = new MapepireDriver();
+        assertFalse(driver.jdbcCompliant());
     }
 }

--- a/src/test/java/io/github/mapepire_ibmi/MapepireDriverTest.java
+++ b/src/test/java/io/github/mapepire_ibmi/MapepireDriverTest.java
@@ -1,0 +1,94 @@
+package io.github.mapepire_ibmi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MapepireDriverTest {
+
+    private MapepireDriver driver;
+
+    @BeforeEach
+    void setUp() {
+        driver = new MapepireDriver();
+    }
+
+    // -------------------------------------------------------------------------
+    // acceptsURL — valid URLs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void acceptsUrlWithHostAndPort() throws SQLException {
+        assertTrue(driver.acceptsURL("jdbc:mapepire://myhost.example.com:8076"));
+    }
+
+    @Test
+    void acceptsUrlWithHostPortAndProperties() throws SQLException {
+        assertTrue(driver.acceptsURL("jdbc:mapepire://myhost.example.com:8076;USER=bob;PASSWORD=secret"));
+    }
+
+    @Test
+    void acceptsUrlIsCaseInsensitive() throws SQLException {
+        // The (?i) flag in the regex makes jdbc:MAPEPIRE:// valid too
+        assertTrue(driver.acceptsURL("JDBC:MAPEPIRE://myhost.example.com:8076"));
+    }
+
+    @Test
+    void acceptsUrlWithIpAddress() throws SQLException {
+        assertTrue(driver.acceptsURL("jdbc:mapepire://192.168.1.100:8076"));
+    }
+
+    @Test
+    void acceptsUrlWithAdditionalJdbcProperties() throws SQLException {
+        assertTrue(driver.acceptsURL("jdbc:mapepire://myhost.example.com:8076;naming=system;errors=full"));
+    }
+
+    // -------------------------------------------------------------------------
+    // acceptsURL — invalid URLs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void rejectsNullUrl() throws SQLException {
+        assertFalse(driver.acceptsURL(null));
+    }
+
+    @Test
+    void rejectsEmptyUrl() throws SQLException {
+        assertFalse(driver.acceptsURL(""));
+    }
+
+    @Test
+    void rejectsWrongScheme() throws SQLException {
+        // Should not accept a standard JDBC URL for another database
+        assertFalse(driver.acceptsURL("jdbc:postgresql://localhost:5432/mydb"));
+    }
+
+    @Test
+    void rejectsUrlWithoutHost() throws SQLException {
+        assertFalse(driver.acceptsURL("jdbc:mapepire://"));
+    }
+
+    @Test
+    void rejectsPlainString() throws SQLException {
+        assertFalse(driver.acceptsURL("not-a-url-at-all"));
+    }
+
+    // -------------------------------------------------------------------------
+    // version
+    // -------------------------------------------------------------------------
+
+    @Test
+    void majorVersionIsOne() {
+        assertEquals(1, driver.getMajorVersion());
+    }
+
+    @Test
+    void minorVersionIsZero() {
+        assertEquals(0, driver.getMinorVersion());
+    }
+}

--- a/src/test/java/io/github/mapepire_ibmi/MapepireResultSetTest.java
+++ b/src/test/java/io/github/mapepire_ibmi/MapepireResultSetTest.java
@@ -1,0 +1,304 @@
+package io.github.mapepire_ibmi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.mapepire_ibmi.types.QueryResult;
+
+class MapepireResultSetTest {
+
+    private MapepireResultSet rs;
+
+    /**
+     * Builds a fake QueryResult from a single row with the given column data.
+     * This simulates what the mapepire-sdk returns after executing a query,
+     * without needing a real IBM i connection.
+     */
+    private MapepireResultSet buildResultSet(Map<String, Object> row) {
+        QueryResult<Object> result = new QueryResult<>();
+        result.setData(Arrays.asList((Object) row));
+        result.setHasResults(true);
+        result.setIsDone(true);
+        return new MapepireResultSet(result);
+    }
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("NAME", "Alice");
+        row.put("AGE", 30);
+        row.put("SALARY", 99.50d);
+        row.put("ACTIVE", true);
+        row.put("SCORE", null);
+
+        rs = buildResultSet(row);
+    }
+
+    // -------------------------------------------------------------------------
+    // next() — row navigation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void nextReturnsTrueWhenRowsExist() throws SQLException {
+        assertTrue(rs.next());
+    }
+
+    @Test
+    void nextReturnsFalseWhenNoMoreRows() throws SQLException {
+        rs.next(); // consume the only row
+        assertFalse(rs.next());
+    }
+
+    @Test
+    void nextReturnsFalseOnEmptyResultSet() throws SQLException {
+        QueryResult<Object> empty = new QueryResult<>();
+        empty.setData(Collections.emptyList());
+        try (MapepireResultSet emptyRs = new MapepireResultSet(empty)) {
+            assertFalse(emptyRs.next());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // getString — by index and by name
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getStringByIndexReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals("Alice", rs.getString(1));
+    }
+
+    @Test
+    void getStringByIndexConvertsIntegerToString() throws SQLException {
+        rs.next();
+        // AGE column is an Integer — must not throw ClassCastException
+        assertEquals("30", rs.getString(2));
+    }
+
+    @Test
+    void getStringByIndexConvertsDoubleToString() throws SQLException {
+        rs.next();
+        assertEquals("99.5", rs.getString(3));
+    }
+
+    @Test
+    void getStringByIndexReturnsNullForNullColumn() throws SQLException {
+        rs.next();
+        assertNull(rs.getString(5));
+    }
+
+    @Test
+    void getStringByNameReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals("Alice", rs.getString("NAME"));
+    }
+
+    @Test
+    void getStringByNameIsCaseInsensitive() throws SQLException {
+        rs.next();
+        // IBM i column names are uppercase — callers may use lowercase
+        assertEquals("Alice", rs.getString("name"));
+    }
+
+    @Test
+    void getStringByNameThrowsForUnknownColumn() throws SQLException {
+        rs.next();
+        assertThrows(SQLException.class, () -> rs.getString("UNKNOWN"));
+    }
+
+    @Test
+    void getStringThrowsWhenNextNotCalled() {
+        // currentRow is null before next() is ever called
+        assertThrows(SQLException.class, () -> rs.getString(1));
+    }
+
+    @Test
+    void getStringThrowsForInvalidIndex() throws SQLException {
+        rs.next();
+        assertThrows(SQLException.class, () -> rs.getString(0));   // below range
+        assertThrows(SQLException.class, () -> rs.getString(99));  // above range
+    }
+
+    // -------------------------------------------------------------------------
+    // getInt / getLong / getDouble / getFloat / getBoolean — typed getters
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getIntByIndexReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals(30, rs.getInt(2));
+    }
+
+    @Test
+    void getIntByNameReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals(30, rs.getInt("AGE"));
+    }
+
+    @Test
+    void getIntReturnsZeroForNullColumn() throws SQLException {
+        rs.next();
+        assertEquals(0, rs.getInt(5)); // SCORE is null
+    }
+
+    @Test
+    void getDoubleByIndexReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals(99.50d, rs.getDouble(3), 0.001);
+    }
+
+    @Test
+    void getDoubleByNameReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals(99.50d, rs.getDouble("SALARY"), 0.001);
+    }
+
+    @Test
+    void getDoubleReturnsZeroForNullColumn() throws SQLException {
+        rs.next();
+        assertEquals(0.0d, rs.getDouble(5), 0.0);
+    }
+
+    @Test
+    void getBooleanByIndexReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertTrue(rs.getBoolean(4));
+    }
+
+    @Test
+    void getBooleanByNameReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertTrue(rs.getBoolean("ACTIVE"));
+    }
+
+    @Test
+    void getBooleanReturnsFalseForNullColumn() throws SQLException {
+        rs.next();
+        assertFalse(rs.getBoolean(5)); // SCORE is null
+    }
+
+    @Test
+    void getLongByIndexReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals(30L, rs.getLong(2));
+    }
+
+    @Test
+    void getFloatByIndexReturnsCorrectValue() throws SQLException {
+        rs.next();
+        assertEquals(99.50f, rs.getFloat(3), 0.01f);
+    }
+
+    // -------------------------------------------------------------------------
+    // getDate / getTime / getTimestamp
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getDateByIndexReturnsCorrectValue() throws SQLException {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("HIREDATE", "2024-03-15");
+        MapepireResultSet dateRs = buildResultSet(row);
+        dateRs.next();
+        assertEquals(Date.valueOf("2024-03-15"), dateRs.getDate(1));
+    }
+
+    @Test
+    void getDateByNameReturnsCorrectValue() throws SQLException {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("HIREDATE", "2024-03-15");
+        MapepireResultSet dateRs = buildResultSet(row);
+        dateRs.next();
+        assertEquals(Date.valueOf("2024-03-15"), dateRs.getDate("HIREDATE"));
+    }
+
+    @Test
+    void getTimeByIndexReturnsCorrectValue() throws SQLException {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("STARTTIME", "14:30:00");
+        MapepireResultSet timeRs = buildResultSet(row);
+        timeRs.next();
+        assertEquals(Time.valueOf("14:30:00"), timeRs.getTime(1));
+    }
+
+    @Test
+    void getTimestampByIndexReturnsCorrectValue() throws SQLException {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("CREATED", "2024-03-15 14:30:00");
+        MapepireResultSet tsRs = buildResultSet(row);
+        tsRs.next();
+        assertEquals(Timestamp.valueOf("2024-03-15 14:30:00"), tsRs.getTimestamp(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // findColumn
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findColumnReturnsCorrectOneBasedIndex() throws SQLException {
+        rs.next();
+        assertEquals(1, rs.findColumn("NAME"));
+        assertEquals(2, rs.findColumn("AGE"));
+        assertEquals(3, rs.findColumn("SALARY"));
+    }
+
+    @Test
+    void findColumnIsCaseInsensitive() throws SQLException {
+        rs.next();
+        assertEquals(1, rs.findColumn("name"));
+        assertEquals(1, rs.findColumn("Name"));
+        assertEquals(1, rs.findColumn("NAME"));
+    }
+
+    @Test
+    void findColumnThrowsForUnknownColumn() throws SQLException {
+        rs.next();
+        assertThrows(SQLException.class, () -> rs.findColumn("NONEXISTENT"));
+    }
+
+    // -------------------------------------------------------------------------
+    // close
+    // -------------------------------------------------------------------------
+
+    @Test
+    void closeNullifiesInternalState() throws SQLException {
+        rs.next();
+        rs.close();
+        // After close, getString should throw because currentRow is null
+        assertThrows(SQLException.class, () -> rs.getString(1));
+    }
+
+    @Test
+    void multipleRowsNavigatedCorrectly() throws SQLException {
+        Map<String, Object> row1 = new LinkedHashMap<>();
+        row1.put("ID", 1);
+        Map<String, Object> row2 = new LinkedHashMap<>();
+        row2.put("ID", 2);
+
+        QueryResult<Object> result = new QueryResult<>();
+        result.setData(Arrays.asList((Object) row1, (Object) row2));
+        result.setHasResults(true);
+        result.setIsDone(true);
+        try (MapepireResultSet multiRs = new MapepireResultSet(result)) {
+            assertTrue(multiRs.next());
+            assertEquals(1, multiRs.getInt(1));
+            assertTrue(multiRs.next());
+            assertEquals(2, multiRs.getInt(1));
+            assertFalse(multiRs.next());
+        }
+    }
+}


### PR DESCRIPTION

This fixes a few bugs that made the driver basically unusable, and adds 48 tests so they stay fixed.

### Bugs fixed

- **Statement never saved the query.** `executeQuery()` / `executeUpdate()` assigned a local `query` variable instead of `this.query`, so `close()` and `getMoreResults()` always NPE'd. Every query was leaking.
- **`getString(int)` crashed on non-String columns.** It hard-cast the value to `String`, so any int, decimal, boolean, or date column threw a `ClassCastException`.
- **Column access by name didn't exist.** Every `get*(String columnLabel)` method threw `UnsupportedOperationException`. Since Hibernate, MyBatis, and Spring JDBC all read columns by name, the driver couldn't actually be used with an ORM.

### What changed

- `this.query` is now set correctly, so `close()` and pagination work
- `getString(int)` uses `.toString()` instead of casting — works for any type
- Added `findColumn(String)` with case-insensitive matching (IBM i columns are uppercase by default, so lowercase lookups now work)
- All the by-name getters now go through `findColumn()`, so lookups behave consistently
- Implemented the rest of the typed getters  `getBoolean`, `getByte`, `getShort`, `getInt`, `getLong`, `getFloat`, `getDouble`, `getBigDecimal`, `getDate`, `getTime`, `getTimestamp` — by both index and name
- Numeric getters return zero for SQL NULL, per the JDBC spec
- uncommented workflow file

### Tests

Added 48 tests across three new test classes, all running in-memory against constructed `QueryResult` objects — no live IBM i connection needed.

- `MapepireResultSetTest` — navigation, all typed getters, nulls, case-insensitive lookups, close behavior, multi-row iteration
- `MapepireDriverTest` — URL validation, version info
- `AppTest` — swapped the old `assertEquals(1, 1)` placeholder for real tests
